### PR TITLE
Feature/fcm 구글 FCM 기능 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-auth:20.5.0'
     implementation 'com.google.firebase:firebase-auth-ktx'
     implementation 'com.google.firebase:firebase-database-ktx'
+    implementation 'com.google.firebase:firebase-messaging-ktx'
 
     // OkHttp
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:name=".TekkenForumApplication"
         android:allowBackup="true"
@@ -11,7 +13,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.TkForum"
-        tools:targetApi="31">
+        tools:targetApi="33">
         <activity
             android:name=".ui.MainActivity"
             android:exported="true"
@@ -22,6 +24,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".service.FirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/nik/tkforum/service/FirebaseMessagingService.kt
+++ b/app/src/main/java/com/nik/tkforum/service/FirebaseMessagingService.kt
@@ -1,0 +1,40 @@
+package com.nik.tkforum.service
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.nik.tkforum.R
+import com.nik.tkforum.util.Constants
+
+class FirebaseMessagingService : FirebaseMessagingService() {
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
+
+        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel =
+                NotificationChannel(
+                    Constants.FCM_CHANNEL_ID,
+                    Constants.FCM_CHANNEL_NAME,
+                    NotificationManager.IMPORTANCE_DEFAULT
+                )
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        val notificationBuilder = NotificationCompat.Builder(applicationContext)
+            .setSmallIcon(R.drawable.ic_app_icon)
+            .setContentTitle(message.data["title"])
+            .setContentText(message.data["body"])
+
+        notificationManager.notify(0, notificationBuilder.build())
+    }
+}

--- a/app/src/main/java/com/nik/tkforum/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/nik/tkforum/ui/setting/SettingFragment.kt
@@ -1,9 +1,12 @@
 package com.nik.tkforum.ui.setting
 
+import android.Manifest
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -45,6 +48,9 @@ class SettingFragment : BaseFragment() {
 
         binding.tvGetFrameInfo.setOnClickListener {
             getNewFrameDialog()
+        }
+        binding.tvNotificationPermission.setOnClickListener {
+            requestNotificationPermission()
         }
     }
 
@@ -181,6 +187,36 @@ class SettingFragment : BaseFragment() {
                         }.show()
                     }
                 }
+        }
+    }
+
+    private val requestPermission = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) {
+        when (it) {
+            true -> {
+                Snackbar.make(
+                    binding.root,
+                    R.string.notification_permission_message,
+                    Snackbar.LENGTH_LONG
+                ).setAction(R.string.close_snack_bar) {
+                }.show()
+            }
+
+            false -> {
+                Snackbar.make(
+                    binding.root,
+                    R.string.notification_permission_denied_message,
+                    Snackbar.LENGTH_LONG
+                ).setAction(R.string.close_snack_bar) {
+                }.show()
+            }
+        }
+    }
+
+    private fun requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            requestPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
     }
 }

--- a/app/src/main/java/com/nik/tkforum/util/Constants.kt
+++ b/app/src/main/java/com/nik/tkforum/util/Constants.kt
@@ -35,4 +35,7 @@ object Constants {
     )
 
     const val CHARACTER_DATA_BASE = "frame_data_data_base"
+
+    const val FCM_CHANNEL_ID = "update_data_Notification_channel"
+    const val FCM_CHANNEL_NAME = "Update data Notification Channel"
 }

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -166,6 +166,27 @@
             app:layout_constraintStart_toStartOf="parent" />
 
         <TextView
+            android:id="@+id/tv_notification_permission"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:paddingStart="16dp"
+            android:text="@string/notification_permission"
+            android:textColor="@color/white"
+            android:gravity="center_vertical"
+            android:textSize="20sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_get_frame_info" />
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:background="@color/grey"
+            app:layout_constraintBottom_toBottomOf="@id/tv_notification_permission"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <TextView
             android:id="@+id/tv_survey"
             android:layout_width="0dp"
             android:layout_height="40dp"
@@ -176,7 +197,7 @@
             android:textSize="20sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_get_frame_info" />
+            app:layout_constraintTop_toBottomOf="@id/tv_notification_permission" />
 
         <View
             android:layout_width="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,4 +54,7 @@
     <string name="dialog_success_get_frame_data_message">앱을 재실행 해주세요</string>
     <string name="dialog_ge_frame_data_title">프레임 데이터를 다운로드합니다.</string>
     <string name="progress_dialog_title">데이터를 받아오는 중입니다\n 잠시 기다려주세요.</string>
+    <string name="notification_permission">데이터 업데이트 알림 받기</string>
+    <string name="notification_permission_message">프레임 데이터 업데이트 소식을 알림으로 받습니다.</string>
+    <string name="notification_permission_denied_message">프레임 데이터 업데이트 관련 중요한 알림을 받아보시려면 알림 권한을 허용해 주세요.</string>
 </resources>


### PR DESCRIPTION
### **구현 내용**

- 구글 FCM 기능 추가로 데이터베이스 내용이 업데이트 될 경우 유저가 메시지를 알림으로 받아볼수 있게 구현

- target api 33 버전 이후 에서 알림 권한 요청하도록 구현